### PR TITLE
Fix key exposure and secure passwords

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
-REACT_APP_GEMINI_API_KEY=AIzaSyDummy_Key_Replace_With_Real_Key
+# Gemini API key for frontend. Fill with your key.
+VITE_GEMINI_API_KEY=
 

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -19,12 +19,21 @@ def test_list_notes_empty(client):
     assert json.loads(rv.data) == []
 
 def test_create_note(client):
-    payload = {"title": "t", "content": "c"}
+    payload = {"title": "t", "content": "c", "password": "p"}
     rv = client.post('/notes', json=payload)
     assert rv.status_code == 201
     data = rv.get_json()
     assert data["title"] == "t"
+    assert data["hasPassword"] is True
+    assert "password" not in data
+
     list_rv = client.get('/notes')
     notes = list_rv.get_json()
     assert len(notes) == 1
     assert notes[0]["title"] == "t"
+    assert notes[0]["hasPassword"] is True
+    assert "password" not in notes[0]
+
+    verify_rv = client.post('/notes/verify-password', json={"id": data["id"], "password": "p"})
+    assert verify_rv.status_code == 200
+    assert verify_rv.get_json()["verified"] is True

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -153,11 +153,11 @@ function App() {
         };
         
         const savedNote = await createNote(noteData);
-        
+
         // Cập nhật danh sách ghi chú local
         setNotes(prevNotes => [...prevNotes, {
           ...savedNote,
-          hasPassword: !!savedNote.password
+          hasPassword: savedNote.hasPassword
         }]);
         
         setNewNote({ title: '', content: '', password: '', deadline: '' });
@@ -203,7 +203,7 @@ function App() {
       const serverNotes = await listNotes();
       setNotes(serverNotes.map(note => ({
         ...note,
-        hasPassword: !!note.password
+        hasPassword: note.hasPassword
       })));
     } catch (error) {
       console.error("Lỗi khi tải ghi chú:", error);

--- a/src/NoteViewer.jsx
+++ b/src/NoteViewer.jsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import './NoteViewer.css';
 
 // API base URL
-const API_BASE = 'https://5000-i2imb1x0gaem4b41tguch-e7a019ae.manusvm.computer';
+const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:5000';
 
 function NoteViewer() {
   const { noteId } = useParams();
@@ -32,8 +32,8 @@ function NoteViewer() {
       }
 
       const noteData = await response.json();
-      
-      if (noteData.password) {
+
+      if (noteData.hasPassword) {
         setIsPasswordRequired(true);
       } else {
         setNote(noteData);
@@ -150,7 +150,7 @@ function NoteViewer() {
                 ⏰ Hết hạn: {new Date(note.deadline).toLocaleString('vi-VN')}
               </span>
             )}
-            {note.password && (
+            {note.hasPassword && (
               <span className="protected">🔒 Có bảo vệ</span>
             )}
           </div>

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,5 @@
 // API helper functions
-const API_BASE = process.env.NODE_ENV === 'production' ? 'https://5000-i2imb1x0gaem4b41tguch-e7a019ae.manusvm.computer' : 'https://5000-i2imb1x0gaem4b41tguch-e7a019ae.manusvm.computer';
+const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:5000';
 
 export const createNote = async (noteData) => {
   const response = await fetch(`${API_BASE}/notes`, {

--- a/src/gemini-api.js
+++ b/src/gemini-api.js
@@ -1,9 +1,12 @@
-// Gemini API helper với key mới
-const GEMINI_API_KEY = 'AIzaSyDbSjSRboXDkxTSJHqogo1Hvmxl2cU9aVA';
+// Gemini API helper. Key is provided via environment variable
+const GEMINI_API_KEY = import.meta.env.VITE_GEMINI_API_KEY;
 const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent';
 
 export const callGeminiAPI = async (prompt, imageBase64 = null) => {
   try {
+    if (!GEMINI_API_KEY) {
+      throw new Error('GEMINI_API_KEY is not configured');
+    }
     const requestBody = {
       contents: [{
         parts: []


### PR DESCRIPTION
## Summary
- secure Gemini API usage by reading key from env vars
- hash note passwords and avoid returning them to clients
- update frontend to use new API structure
- adjust tests for hashed passwords

## Testing
- `pnpm test` *(fails: network error)*
- `pytest -q` *(fails: missing Flask dependency)*

------
https://chatgpt.com/codex/tasks/task_b_687749b76cbc8323a3515e319a627543